### PR TITLE
Fix settings file ending between versions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: yarn
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/docs/setup/docker/configuring.mdx
+++ b/docs/setup/docker/configuring.mdx
@@ -8,4 +8,8 @@ import Configuring from '@site/shared/configuring.mdx'
 
 Now it's time to configure the bot itself, by setting up your `settings.yml`. First, download the [sample settings file](https://raw.githubusercontent.com/fluid-queue/fluid-queue/develop/settings/settings.example.yml) from git and save it as `settings.yml` in your settings folder (next to your `tokens.json`).
 
+## settings.yml
+
+`settings.yml` is where most of the customization of the bot occurs. There's a lot of customization to do, and most of the options are safe to leave as the defaults, but there are a few to make sure you update, marked with **[!]** to make it easier to notice! Open your `settings.yml` in a text editor and customize it as necessary, making sure to update all the marked items.
+
 <Configuring />

--- a/docs/setup/native/configuring.mdx
+++ b/docs/setup/native/configuring.mdx
@@ -8,4 +8,8 @@ import Configuring from '@site/shared/configuring.mdx'
 
 Now it's time to configure the bot itself, by setting up your `settings.yml` file. Open up `settings/settings.yml` in your text editor.
 
+## settings.yml
+
+`settings.yml` is where most of the customization of the bot occurs. There's a lot of customization to do, and most of the options are safe to leave as the defaults, but there are a few to make sure you update, marked with **[!]** to make it easier to notice! Open your `settings.yml` in a text editor and customize it as necessary, making sure to update all the marked items.
+
 <Configuring />

--- a/shared/configuring.mdx
+++ b/shared/configuring.mdx
@@ -1,7 +1,3 @@
-## settings.yml
-
-`settings.yml` is where most of the customization of the bot occurs. There's a lot of customization to do, and most of the options are safe to leave as the defaults, but there are a few to make sure you update, marked with **[!]** to make it easier to notice! Open your `settings.json` in a text editor and customize it as necessary, making sure to update all the marked items.
-
 - **[!]** `channel` is the channel that the bot will run in. This should be your Twitch account username, only containing underscores and lowercase alphanumeric characters.
 - **[!]** `clientId` is the client ID you received from Twitch when you registered your application in the last section. Again, don't include the braces.
 - **[!]** `clientSecret` is the client secret you received from Twitch in the last section. No braces!

--- a/versioned_docs/version-2.0.0-beta.3/setup/docker/configuring.mdx
+++ b/versioned_docs/version-2.0.0-beta.3/setup/docker/configuring.mdx
@@ -8,4 +8,8 @@ import Configuring from '@site/shared/configuring.mdx'
 
 Now it's time to configure the bot itself, by setting up your `settings.json`. First, download the [sample settings file](https://raw.githubusercontent.com/fluid-queue/fluid-queue/main/settings/settings.example.json) from git and save it as `settings.json` in your settings folder (next to your `tokens.json`).
 
+## settings.json
+
+`settings.json` is where most of the customization of the bot occurs. There's a lot of customization to do, and most of the options are safe to leave as the defaults, but there are a few to make sure you update, marked with **[!]** to make it easier to notice! Open your `settings.json` in a text editor and customize it as necessary, making sure to update all the marked items.
+
 <Configuring />

--- a/versioned_docs/version-2.0.0-beta.3/setup/native/configuring.mdx
+++ b/versioned_docs/version-2.0.0-beta.3/setup/native/configuring.mdx
@@ -8,4 +8,8 @@ import Configuring from '@site/shared/configuring.mdx'
 
 Now it's time to configure the bot itself, by setting up your `settings.json` file. Open up `settings/settings.json` in your text editor.
 
+## settings.json
+
+`settings.json` is where most of the customization of the bot occurs. There's a lot of customization to do, and most of the options are safe to leave as the defaults, but there are a few to make sure you update, marked with **[!]** to make it easier to notice! Open your `settings.json` in a text editor and customize it as necessary, making sure to update all the marked items.
+
 <Configuring />


### PR DESCRIPTION
Currently version `2.0.0-beta.3` is talking about `settings.yml`, but yet it only supports `settings.json`.
Also the `develop` version has a `settings.json` in there as well.

This PR should fix this.