### PR TITLE
Add a link to the next step for compiling the bot

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: yarn
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/docs/setup/native/index.md
+++ b/docs/setup/native/index.md
@@ -9,7 +9,7 @@ You'll also need a copy of the bot. We would recommend going to our [releases pa
 <summary>Advanced use: building the bot from source</summary>
 
 For advanced users, you can also download a source archive or clone the repository with `git clone https://github.com/fluid-queue/fluid-queue`. Our prepackaged releases are already bundled and minified, so these methods will require a bit of extra effort (and installation of a substantial `node_modules` folder). We'd recommend using the prepackaged releases for greater simplicity, though we will still support building from source.
-
+The [next step](./setup/) will explain how to compile the bot.
 </details>
 
 Once you've downloaded and extracted a release (or cloned the bot from git), proceed to the next step.

--- a/docs/setup/native/index.md
+++ b/docs/setup/native/index.md
@@ -9,7 +9,7 @@ You'll also need a copy of the bot. We would recommend going to our [releases pa
 <summary>Advanced use: building the bot from source</summary>
 
 For advanced users, you can also download a source archive or clone the repository with `git clone https://github.com/fluid-queue/fluid-queue`. Our prepackaged releases are already bundled and minified, so these methods will require a bit of extra effort (and installation of a substantial `node_modules` folder). We'd recommend using the prepackaged releases for greater simplicity, though we will still support building from source.
-The [next step](./setup/) will explain how to compile the bot.
+The [next step](setup.md) will explain how to compile the bot.
 </details>
 
 Once you've downloaded and extracted a release (or cloned the bot from git), proceed to the next step.


### PR DESCRIPTION
On the native setup page there is documentation about the bot needing to be compiled.
However there are no instructions how to compile the bot, but there are instructions how to do that in the next step.

I added a link to the next step, essentially explaining that the next step will explain how to do that.